### PR TITLE
First use tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/artifacts
 /target
 /result

--- a/nix/load.nix
+++ b/nix/load.nix
@@ -30,9 +30,14 @@ args:
 
 let
   src = toString (
-    args.src or (warn
-      "namaka.load: `flake` and `dir` have been deprecated, use `src` directly instead"
-      (args.flake + "/${args.dir or "tests"}"))
+    if args ? src then
+      args.src
+    else if args ? flake then
+      warn
+        "namaka.load: `flake` and `dir` have been deprecated, use `src` directly instead"
+        (args.flake + "/${args.dir or "tests"}")
+    else
+      throw "namaka.load: missing mandatory `src' argument"
   );
 
   tests = haumea.load (removeAttrs args [ "flake" "dir" ] // {

--- a/src/cmd/check.rs
+++ b/src/cmd/check.rs
@@ -1,6 +1,7 @@
 use std::{
     fs::{self, create_dir_all, remove_dir_all, File},
     io::{stderr, BufRead, Write},
+    path::Path,
     process::exit,
 };
 
@@ -14,7 +15,7 @@ use crate::{
     proto::{TestOutput, TestResult},
 };
 
-pub fn check(opts: Opts, cfg: Option<Config>) -> Result<()> {
+pub fn check(root: &Path, opts: Opts, cfg: Option<Config>) -> Result<()> {
     let output = nix_check(opts, cfg)?;
     let success = output.status.success();
 
@@ -26,7 +27,7 @@ pub fn check(opts: Opts, cfg: Option<Config>) -> Result<()> {
 
         let output = serde_json::from_str::<TestOutput>(line)?;
 
-        let pending = output.dir.join("_snapshots").join(".pending");
+        let pending = root.join(output.dir).join("_snapshots/.pending");
         let _ = remove_dir_all(&pending);
         create_dir_all(&pending)?;
         fs::write(pending.join(".gitignore"), "*")?;

--- a/src/cmd/clean.rs
+++ b/src/cmd/clean.rs
@@ -1,5 +1,6 @@
 use std::{
     fs::{read_dir, remove_dir_all, remove_file},
+    path::Path,
     io::{stderr, BufRead, Write},
 };
 
@@ -8,7 +9,7 @@ use owo_colors::OwoColorize;
 
 use crate::{cfg::Config, cli::Opts, cmd::run::nix_eval, proto::TestOutput};
 
-pub fn clean(opts: Opts, cfg: Option<Config>) -> Result<()> {
+pub fn clean(root: &Path, opts: Opts, cfg: Option<Config>) -> Result<()> {
     let output = nix_eval(opts, cfg)?;
 
     for line in output.stderr.lines() {
@@ -19,7 +20,7 @@ pub fn clean(opts: Opts, cfg: Option<Config>) -> Result<()> {
 
         let mut out = stderr().lock();
         let output = serde_json::from_str::<TestOutput>(line)?;
-        let snapshots = output.dir.join("_snapshots");
+        let snapshots = root.join(output.dir).join("_snapshots");
 
         for entry in read_dir(snapshots)? {
             let entry = entry?;

--- a/src/cmd/review.rs
+++ b/src/cmd/review.rs
@@ -17,7 +17,7 @@ use crate::{
     proto::{Snapshot, TestOutput},
 };
 
-pub fn review(opts: Opts, cfg: Option<Config>) -> Result<()> {
+pub fn review(root: &Path, opts: Opts, cfg: Option<Config>) -> Result<()> {
     let output = nix_eval(opts, cfg)?;
 
     for line in output.stderr.lines() {
@@ -27,7 +27,7 @@ pub fn review(opts: Opts, cfg: Option<Config>) -> Result<()> {
         };
 
         let output = serde_json::from_str::<TestOutput>(line)?;
-        let snapshots = output.dir.join("_snapshots");
+        let snapshots = root.join(output.dir).join("_snapshots");
 
         for entry in read_dir(snapshots.join(".pending"))? {
             use bstr::ByteSlice;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,9 +23,22 @@ fn main() -> Result<()> {
 
     let cfg = cfg::load()?;
 
+    let root = repo_root()?;
+
     match opts.subcmd {
-        Subcommand::Check => check(opts, cfg),
-        Subcommand::Clean => clean(opts, cfg),
-        Subcommand::Review => review(opts, cfg),
+        Subcommand::Check => check(&root, opts, cfg),
+        Subcommand::Clean => clean(&root, opts, cfg),
+        Subcommand::Review => review(&root, opts, cfg),
     }
+}
+
+fn repo_root() -> Result<std::path::PathBuf> {
+    let mut cmd = std::process::Command::new("git");
+    cmd.args(["rev-parse", "--show-toplevel"]);
+
+    let out = cmd.output()?;
+    let str = std::str::from_utf8(&out.stdout)?;
+    let str = str.trim_end();
+
+    Ok(str.to_owned().into())
 }


### PR DESCRIPTION
Hi, thanks for building this and haumea, both are cool projects!

Here's a couple changes I did when getting setup. If you'd like me to split this in any way, let me know.  
All changes are pretty small though.

1. > fix: interpret path printed by nix as relative to repo root
    >
    > This was causing `check` to always see the tests as new/failing, but
    > `review` to show a diff with no changes.

   My setup is similar to the subflake template, so it's probably worth adding automated tests for the templates as that would've probably caught this bug.

2.  > feat(check): track test additions separately from failures
    >
    > Tweak the output so those cases are more easily distinguishable,
    > especially the color used by the `+` symbol next to the test name.
    > Exit code is now 2 if all existing tests succeeded, but some were added.

    Here's an example output in the common case:
    ![image](https://github.com/nix-community/namaka/assets/4761135/2e225673-2194-46c7-a8b9-96e06dff5a3e)
    Here's a comparison of "failing and added state" which is what motivated me to change this:
    ![image](https://github.com/nix-community/namaka/assets/4761135/7bdff5e7-8451-4c38-a60e-92f6df93c01d)
    ![image](https://github.com/nix-community/namaka/assets/4761135/aabe432d-d081-40a9-a0a4-4495865a57d8)

3. > fix: only show flake and dir warning when relevant
    >
    > Forgetting to set `src` was triggering it.
    > Ideally we'd just change the function to use `{ src, ... }@args:` so Nix
    > can provide an explicit error the users are accustomed to.

